### PR TITLE
on restart everything borked. turned out it was pathing for local and…

### DIFF
--- a/go/src/dataProcessors/parse.go
+++ b/go/src/dataProcessors/parse.go
@@ -13,7 +13,6 @@ package dataProcessors
  * leaving these sloppy notes here until I can get some intuition for it
  */
 
-
 /*
  * This one uses the 3rd-party module "etree" for more fast and loose (and better?) xml parsing
  * etree is very forgiving of mismatches between struct and xml source
@@ -23,7 +22,8 @@ import (
 	// "fmt"
 	"strings"
 
-	"utils/etree"
+	"github.com/felixge/etree"
+	// "utils/etree"
 )
 
 
@@ -49,6 +49,10 @@ type Monster struct {
 	Traits []map[string]string
 	Actions []map[string]string
 	Legendary []map[string]string
+	Immune string
+	Senses string
+	Vulnerable string
+	Resist string
 }
 
 var Monsters = make(map[string]Monster)

--- a/go/src/main.go
+++ b/go/src/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"errors"
+	"fmt"
+
 	// "io"
 	"net/http"
 	"os"
+	"src/dataProcessors"
 )
-
-import "dataProcessors"
 
 func monsterPtrToJSON(m *dataProcessors.Monster) []byte {
 	var buffer bytes.Buffer


### PR DESCRIPTION
… remote imports

local dataProcessors/parse.go required importing "src/dataProcessors" instead of "dataProcessors"

local copy of 3rd-party xml parser "etree" wasn't loading. changed import to use the github address instead of local copy

this all happened after restarting host machine--ie this runs in a docker container